### PR TITLE
Claim otherwise unused system GIDs for device nodes

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -18,8 +18,8 @@ repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?re
 #repo --name=updates-testing --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-testing-f$releasever&arch=$basearch
 repo --name=enarx --baseurl=https://download.copr.fedorainfracloud.org/results/npmccallum/enarx/fedora-$releasever-$basearch/
 
-group --name=sgx
-group --name=sev
+group --name=sgx --gid=300
+group --name=sev --gid=301
 
 ## User Policy
 ## 1. User names MUST match GitHub accounts


### PR DESCRIPTION
```
$ grep -E 'sev|sgx' /etc/group
sgx:x:300:npmccallum,mbestavros,lkatalin,connorkuehl,whitebrandy,haraldh
sev:x:301:npmccallum,mbestavros,lkatalin,connorkuehl,whitebrandy,haraldh
```

I was hoping there'd be a switch for the kickstart `group` command like in `groupadd`:

```
       -r, --system
           Create a system group.

           The numeric identifiers of new system groups are chosen in the SYS_GID_MIN-SYS_GID_MAX range, defined in login.defs,
           instead of GID_MIN-GID_MAX.
```

Alas, there is not.

300 and 301 are unused on the base system.

Closes https://github.com/enarx/enarx/issues/439.