### PR TITLE
Move ssh configuration from /etc/ssh to /home/sshd

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -97,6 +97,15 @@ Type=ether
 [Network]
 DHCP=yes
 EOF
+
+if ! [[ -d /home/sshd ]]; then
+   mv /etc/ssh /home/sshd
+else
+   rm -fr /etc/ssh
+fi
+
+ln -fs /home/sshd /etc/ssh
+
 %end
 
 %pre


### PR DESCRIPTION
This enables persistent sshd keys across (re-)installs