### PR TITLE
Run the Github Actions runner in a container

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -123,6 +123,13 @@ fi
 
 ln -fs /home/sshd /etc/ssh
 
+podman run -d \
+  -e GITHUB_REPOSITORY="https://github.com/enarx/enarx" \
+  -e GITHUB_TOKEN="$(cat PATH_TO_TOKEN)" \
+  -e RUNNER_NAME="$(cat PATH_TO_NAME)" \
+  -e REPLACE_EXISTING_RUNNER="true" \
+  joeyx22lm/docker-github-actions-runner
+
 %end
 
 %pre


### PR DESCRIPTION
Adds the Podman command to stand up and run the Github Actions application in a container.

This command will:

1) create a new Actions runner if one with the same name doesn't already exist;
2) recreate an Actions runner if one with the same name already exists.

This should result in an Actions setup that will appear consistent from Github's perspective, even if we are fully wiping and restarting the system from scratch on our end.

There are a few key details missing at the moment, hence why this is submitted as a draft:

- Standing up a runner requires a Github-provided token, which is provisioned when manually adding a runner in a Github repo's Settings page. I'm operating under the assumption that the token will exist as some yet-unknown file on disk, and have left the path as a placeholder.

- I've taken the same approach for the runner's name; it's currently a placeholder.