### PR TITLE
gha: don't fail the whole script if `podman stop` fails

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -180,7 +180,7 @@ set -e
 [ -e /dev/sgx/enclave ] && dev="-v /dev/sgx/enclave:/dev/sgx/enclave"
 [ -e /dev/sev ] && dev="-v /dev/sev:/dev/sev"
 
-podman stop -i $1
+podman stop -i $1 || true
 podman rm -i $1
 exec podman run --rm -t --name $1 -v "$HOME/$1":/srv:ro,Z $dev quay.io/enarx/gha-runner
 EOF


### PR DESCRIPTION
This can sometimes fail when podman is already bringing down the container.
Therefore, we let `podman stop` fail and continue straight on to `podman rm`,
which succeeds. Without this, restarting the runners would sporadically fail
and then take down the runner completely.