### PR TITLE
Add a shared cache for the SEV certificate chain and mount it into the GHA runner

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -83,6 +83,7 @@ vim-enhanced
 qemu-system-x86
 tmux
 asciinema
+sevctl
 
 gcc
 musl-gcc
@@ -159,6 +160,10 @@ EOF
 # Enable SEV
 echo 'options kvm_amd sev=1' > /etc/modprobe.d/kvm-amd.conf
 
+# Create shared directory for caching SEV certificate chain
+mkdir -m 0755 -p /var/cache/amd-sev
+sevctl export --full /var/cache/amd-sev/chain
+
 # Persist SSH keys across installs
 if ! [[ -d /home/sshd ]]; then
    mv /etc/ssh /home/sshd
@@ -176,6 +181,7 @@ set -e
 [ -e /dev/sgx/enclave ] && dev="$dev -v /dev/sgx/enclave:/dev/sgx/enclave"
 [ -e /dev/sev ] && dev="$dev -v /dev/sev:/dev/sev"
 [ -e /dev/kvm ] && dev="$dev -v /dev/kvm:/dev/kvm"
+[ -e /dev/sev ] && [ -e /var/cache/amd-sev ] && dev="$dev -v /var/cache/amd-sev:/var/cache/amd-sev"
 
 podman stop -i $1 || true
 podman rm -i $1


### PR DESCRIPTION
This directory is where all code paths will be updated to lead
to checking for cached certificate chains. This is motivated by
the need to have an SEV workflow that can scale hosting multiple
developers and potential CI jobs on the same machine. Right now,
there is an implicit "last person to cache wins" mode of operation
that is confusing and undocumented.

This patch lays the groundwork for our CI & developer machine to
*have* a shared directory to cache this certificate chain as well
as mount it into the GHA runner container so that the cached
certificate chain can be automatically updated by the CI when it
invalidates the cached certificate chain when it runs
dangerous_hw_tests.

The CI will always cache a valid certificate chain before and
after its runs. However, this patch does not solve the problem
of a developer running "dangerous_hw_tests" and forgetting to
cache a new chain. That will need to be addressed separately.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

Related: https://github.com/enarx/sev/issues/25