### PR TITLE
fix(sgx): correct the sgx device nodes

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -153,10 +153,16 @@ EOF
 
 # Set SGX and SEV device node permissions
 echo 'KERNEL=="sev", MODE="0666"' > /etc/udev/rules.d/50-sev.rules
-cat > /etc/udev/rules.d/50-sgx.rules <<EOF
-SUBSYSTEM=="misc", KERNEL=="provision", MODE="0600"
-SUBSYSTEM=="misc", KERNEL=="enclave", MODE="0666"
+
+# The udev rules provided by aesmd 92-sgx-provision.rules are incorrect
+# overwrite them and provida backwards compatible symlinks
+cat > /etc/udev/rules.d/99-sgx.rules <<EOF
+SUBSYSTEM=="misc", KERNEL=="sgx_provision", SYMLINK="sgx/provision", MODE="0660", GROUP="sgx_prv"
+SUBSYSTEM=="misc", KERNEL=="sgx_enclave", SYMLINK="sgx/enclave", MODE="0666"
 EOF
+
+# aesmd wants a system group, but the scripts are doing it without `-r`
+groupadd -r sgx_prv
 
 # Increase the memlock limit for SEV keeps (need to pin a large
 # number of pages)


### PR DESCRIPTION
The udev rules provided by aesmd 92-sgx-provision.rules are incorrect.
Overwrite them and provida backwards compatible symlinks.

aesmd wants a system group, but the scripts are doing it without `-r`,
so add the group here.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
