### PR TITLE
fix: enable user lingering for user `gha`

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -240,6 +240,11 @@ WantedBy=multi-user.target
 EOF
 ln -s /etc/systemd/system/gha@.service /etc/systemd/system/multi-user.target.wants/gha@enarx.service
 
+# Enable user lingering for user `gha`.
+# If enabled for a specific user, a user manager is spawned for the user at boot
+# and kept around after logouts.
+loginctl enable-linger gha
+
 # Extend the SELinux policy to use device nodes in containers
 TMPDIR=$(mktemp -d)
 push "$TMPDIR"


### PR DESCRIPTION
Fixes:
```
WARN[0000] The cgroupv2 manager is set to systemd but there is no systemd user session available
WARN[0000] For using systemd, you may need to login using an user session
WARN[0000] Alternatively, you can enable lingering with: `loginctl enable-linger 1009` (possibly as root)
WARN[0000] Falling back to --cgroup-manager=cgroupfs
```