### PR TITLE
Two changes to enable kickstart on Milan systems

### DIFF
--- a/enarx.ipxe
+++ b/enarx.ipxe
@@ -3,6 +3,6 @@
 set base http://sjc.edge.kernel.org/fedora-buffet/fedora/linux/releases/34/Server/x86_64/os
 set ks https://raw.githubusercontent.com/enarx/packet.com/master/enarx.ks
 
-kernel ${base}/images/pxeboot/vmlinuz inst.stage2=${base}/ inst.ks=${ks} initrd=initrd.img console=ttyS1,115200 log_buf_len=2M
+kernel ${base}/images/pxeboot/vmlinuz inst.stage2=${base}/ inst.ks=${ks} initrd=initrd.img console=ttyS0,115200 console=ttyS1,115200 console=tty0 log_buf_len=2M
 initrd ${base}/images/pxeboot/initrd.img
 boot

--- a/enarx.ks
+++ b/enarx.ks
@@ -132,6 +132,7 @@ import os
 
 hostnames = [
     "coffeelake.sgx.lab.enarx.dev",
+    "milan.sev.lab.enarx.dev",
     "rome.sev.lab.enarx.dev",
 ]
 


### PR DESCRIPTION
This boils down to adding hostname support and enabling console on `ttyS0`.