### PR TITLE
Add WebAssembly tools to kickstart

### DIFF
--- a/enarx.ks
+++ b/enarx.ks
@@ -115,6 +115,9 @@ gdb
 
 openssl-devel
 
+wabt
+binaryen
+
 -dracut-config-generic
 -dracut-config-rescue
 -usb_modeswitch


### PR DESCRIPTION
It'd be useful to have WebAssembly tools like `wat2wasm` on our development systems. The upstream WebAssembly tools aren't Rust-based, so you can't `cargo install` them, but they are available as Fedora packages, so this commit adds `wabt` and `binaryen` to the kickstart `%packages` section.

Signed-off-by: Will Woods <will@profian.com>
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
